### PR TITLE
Fix systemd service file path for Debian Jessie

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -98,7 +98,7 @@ class kibana::install (
 
     file { 'kibana-init-script':
       ensure  => file,
-      path    => '/usr/lib/systemd/system/kibana.service',
+      path    => "${::kibana::params::systemd_provider_path}/kibana.service",
       content => template('kibana/kibana.service.erb'),
       notify  => Class['::kibana::service'],
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,8 +33,9 @@ class kibana::params {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'OracleLinux', 'SLC': {
 
       if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
-        $service_provider     = 'systemd'
-        $run_path             = '/run/kibana'
+        $service_provider      = 'systemd'
+        $systemd_provider_path = '/usr/lib/systemd/system'
+        $run_path              = '/run/kibana'
       } else {
         $service_provider        = 'init'
         $run_path                = '/var/run'
@@ -46,8 +47,9 @@ class kibana::params {
     'Debian': {
 
       if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
-        $service_provider = 'systemd'
-        $run_path         = '/run/kibana'
+        $service_provider      = 'systemd'
+        $systemd_provider_path = '/lib/systemd/system'
+        $run_path              = '/run/kibana'
       } else {
         $service_provider        = 'init'
         $run_path                = '/var/run'
@@ -58,8 +60,9 @@ class kibana::params {
     'Ubuntu': {
 
       if versioncmp($::operatingsystemmajrelease, '15') >= 0 {
-        $service_provider = 'systemd'
-        $run_path         = '/run/kibana'
+        $service_provider      = 'systemd'
+        $systemd_provider_path = '/usr/lib/systemd/system'
+        $run_path              = '/run/kibana'
       } else {
         $service_provider        = 'init'
         $run_path                = '/var/run'
@@ -68,8 +71,9 @@ class kibana::params {
     }
 
     'OpenSuSE': {
-      $service_provider  = 'systemd'
-      $run_path          = '/run/kibana'
+      $service_provider      = 'systemd'
+      $systemd_provider_path = '/usr/lib/systemd/system'
+      $run_path              = '/run/kibana'
     }
 
     'Amazon': {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -164,7 +164,7 @@ describe 'kibana::install', :type => :class do
     it { should contain_file('/opt/kibana').with(:target => '/opt/kibana-4.0.1-linux-x64') }
   end
 
-  context 'when running on Debian' do
+  context 'when running on Debian Wheezy' do
     let (:facts) {
       default_facts.merge({
         :osfamily => 'Debian',
@@ -176,6 +176,20 @@ describe 'kibana::install', :type => :class do
     let(:pre_condition) { 'include kibana' }
 
     it { should contain_file('kibana-init-script').with(:path => '/etc/init.d/kibana', :content => /\/lib\/lsb\/init-functions/) }
+  end
+
+  context 'when running on Debian Jessie' do
+    let (:facts) {
+      default_facts.merge({
+        :osfamily => 'Debian',
+        :operatingsystem => 'Debian',
+        :operatingsystemmajrelease => '8',
+      })
+    }
+
+    let(:pre_condition) { 'include kibana' }
+
+    it { should contain_file('kibana-init-script').with(:path => '/lib/systemd/system/kibana.service', :content => /ExecStart=\/opt\/kibana\/bin\/kibana/) }
   end
 
   context 'ensure init script is POSIX compatible' do


### PR DESCRIPTION
The systemd service file path is under `/lib/systemd/system` on Debian Jessie/8.